### PR TITLE
Mlim fix

### DIFF
--- a/source/gaussqr/gqr_solveprep.m
+++ b/source/gaussqr/gqr_solveprep.m
@@ -185,8 +185,10 @@ switch reg
         end
 
         MarrN = gqr_formMarr(zeros(d,1),[],N);
-        Mlim = ceil(N+log(eps)/log(lam));
-
+        %Mlim = ceil(N+log(eps)/log(lam));
+        K = max(sum(MarrN-1, 1));
+        Mlim = ceil(K+log(eps)/log(lam));
+        
         % This needs to get better
         % Specifically it needs to handle people passing weird stuff
         if not(exist('M','var'))


### PR DESCRIPTION
Added a fix for Mlim. It now works with |N| instead of the overall number of basis functions N.